### PR TITLE
Add mira voice command tools

### DIFF
--- a/augmentos_cloud/packages/cloud/src/index.ts
+++ b/augmentos_cloud/packages/cloud/src/index.ts
@@ -29,6 +29,7 @@ import devRoutes from './routes/developer.routes';
 import serverRoutes from './routes/server.routes';
 import adminRoutes from './routes/admin.routes';
 import tpaServerRoutes from './routes/tpa-server.routes';
+import toolsRoutes from './routes/tools.routes';
 
 import path from 'path';
 
@@ -126,7 +127,7 @@ app.use('/api/dev', devRoutes);
 app.use('/api/admin', adminRoutes);
 app.use('/api/tpa-server', tpaServerRoutes);
 app.use('/api/server', serverRoutes);
-
+app.use('/api/tools', toolsRoutes);
 app.use(errorReportRoutes);
 app.use(transcriptRoutes);
 

--- a/augmentos_cloud/packages/cloud/src/models/app.model.ts
+++ b/augmentos_cloud/packages/cloud/src/models/app.model.ts
@@ -1,24 +1,10 @@
 // cloud/server/src/models/app.model.ts
 import mongoose, { Schema, Document, Types } from 'mongoose';
-import { AppI as _AppI, TpaType } from '@augmentos/sdk';
+import { AppI as _AppI, TpaType, ToolSchema, ToolParameterSchema } from '@augmentos/sdk';
 
 export type AppStoreStatus = 'DEVELOPMENT' | 'SUBMITTED' | 'REJECTED' | 'PUBLISHED';
 
-// Tool parameter type definition
-export interface ToolParameterSchema {
-  type: 'string' | 'number' | 'boolean';
-  description: string;
-  enum?: string[];
-  required?: boolean;
-}
 
-// Tool schema definition for TPAs
-export interface ToolSchema {
-  id: string;
-  description: string;
-  activationPhrases?: string[];
-  parameters?: Record<string, ToolParameterSchema>;
-}
 
 // Extend the AppI interface for our MongoDB document
 export interface AppI extends _AppI, Document {

--- a/augmentos_cloud/packages/cloud/src/models/app.model.ts
+++ b/augmentos_cloud/packages/cloud/src/models/app.model.ts
@@ -4,6 +4,22 @@ import { AppI as _AppI, TpaType } from '@augmentos/sdk';
 
 export type AppStoreStatus = 'DEVELOPMENT' | 'SUBMITTED' | 'REJECTED' | 'PUBLISHED';
 
+// Command parameter type definition
+export interface CommandParameterSchema {
+  type: 'string' | 'number' | 'boolean';
+  description: string;
+  enum?: string[];
+  required?: boolean;
+}
+
+// Command schema definition for TPAs
+export interface CommandSchema {
+  id: string;
+  description: string;
+  phrases: string[];
+  parameters?: Record<string, CommandParameterSchema>;
+}
+
 // Extend the AppI interface for our MongoDB document
 export interface AppI extends _AppI, Document {
   createdAt: Date;
@@ -15,6 +31,7 @@ export interface AppI extends _AppI, Document {
   reviewNotes?: string;
   reviewedBy?: string;
   reviewedAt?: Date;
+  commands?: CommandSchema[];
 }
 
 // Using existing schema with flexible access
@@ -42,7 +59,46 @@ const AppSchema = new Schema({
   },
   reviewedAt: {
     type: Date
-  }
+  },
+  
+  // TPA Spoken Commands
+  commands: [{
+    id: {
+      type: String,
+      required: true
+    },
+    description: {
+      type: String,
+      required: true
+    },
+    phrases: {
+      type: [String],
+      required: true
+    },
+    parameters: {
+      type: Map,
+      of: new Schema({
+        type: {
+          type: String,
+          enum: ['string', 'number', 'boolean'],
+          required: true
+        },
+        description: {
+          type: String,
+          required: true
+        },
+        enum: {
+          type: [String],
+          required: false
+        },
+        required: {
+          type: Boolean,
+          default: false
+        }
+      }),
+      required: false
+    }
+  }]
 }, { 
   strict: false,
   timestamps: true 

--- a/augmentos_cloud/packages/cloud/src/models/app.model.ts
+++ b/augmentos_cloud/packages/cloud/src/models/app.model.ts
@@ -4,20 +4,20 @@ import { AppI as _AppI, TpaType } from '@augmentos/sdk';
 
 export type AppStoreStatus = 'DEVELOPMENT' | 'SUBMITTED' | 'REJECTED' | 'PUBLISHED';
 
-// Command parameter type definition
-export interface CommandParameterSchema {
+// Tool parameter type definition
+export interface ToolParameterSchema {
   type: 'string' | 'number' | 'boolean';
   description: string;
   enum?: string[];
   required?: boolean;
 }
 
-// Command schema definition for TPAs
-export interface CommandSchema {
+// Tool schema definition for TPAs
+export interface ToolSchema {
   id: string;
   description: string;
-  phrases: string[];
-  parameters?: Record<string, CommandParameterSchema>;
+  activationPhrases?: string[];
+  parameters?: Record<string, ToolParameterSchema>;
 }
 
 // Extend the AppI interface for our MongoDB document
@@ -31,7 +31,7 @@ export interface AppI extends _AppI, Document {
   reviewNotes?: string;
   reviewedBy?: string;
   reviewedAt?: Date;
-  commands?: CommandSchema[];
+  tools?: ToolSchema[];
 }
 
 // Using existing schema with flexible access
@@ -61,8 +61,8 @@ const AppSchema = new Schema({
     type: Date
   },
   
-  // TPA Spoken Commands
-  commands: [{
+  // TPA AI Tools
+  tools: [{
     id: {
       type: String,
       required: true
@@ -71,9 +71,9 @@ const AppSchema = new Schema({
       type: String,
       required: true
     },
-    phrases: {
+    activationPhrases: {
       type: [String],
-      required: true
+      required: false
     },
     parameters: {
       type: Map,

--- a/augmentos_cloud/packages/cloud/src/routes/admin.routes.ts
+++ b/augmentos_cloud/packages/cloud/src/routes/admin.routes.ts
@@ -91,35 +91,35 @@ const getAppDetail = async (req: Request, res: Response) => {
 };
 
 /**
- * Trigger a command webhook to a TPA
- * Used by Mira AI to send commands to TPAs
+ * Trigger a tool webhook to a TPA
+ * Used by Mira AI to send tools to TPAs
  */
-const triggerCommand = async (req: Request, res: Response) => {
+const triggerTool = async (req: Request, res: Response) => {
   try {
     const { packageName } = req.params;
     const payload = req.body;
     
     // Validate the payload has the required fields
-    if (!payload.command_id) {
+    if (!payload.tool_id) {
       return res.status(400).json({ 
         error: true, 
-        message: 'Missing required field: command_id' 
+        message: 'Missing required field: tool_id' 
       });
     }
     
-    // Log the command request
-    logger.info(`Triggering command webhook for app ${packageName}`, {
-      command_id: payload.command_id,
+    // Log the tool request
+    logger.info(`Triggering tool webhook for app ${packageName}`, {
+      tool_id: payload.tool_id,
       user_id: payload.user_id
     });
     
     // Call the service method to trigger the webhook
-    const result = await appService.triggerTpaCommandWebhook(packageName, payload);
+    const result = await appService.triggerTpaToolWebhook(packageName, payload);
     
     // Return the response from the TPA
     return res.status(result.status).json(result.data);
   } catch (error) {
-    logger.error('Error triggering command webhook:', error);
+    logger.error('Error triggering tool webhook:', error);
     return res.status(500).json({ 
       error: true,
       message: error instanceof Error ? error.message : 'Unknown error occurred' 
@@ -128,20 +128,20 @@ const triggerCommand = async (req: Request, res: Response) => {
 };
 
 /**
- * Get all commands for a specific TPA
- * Used by Mira AI to discover available commands
+ * Get all tools for a specific TPA
+ * Used by Mira AI to discover available tools
  */
-const getTpaCommands = async (req: Request, res: Response) => {
+const getTpaTools = async (req: Request, res: Response) => {
   try {
     const { packageName } = req.params;
     
-    // Call the service method to get the commands
-    const commands = await appService.getTpaCommands(packageName);
+    // Call the service method to get the tools
+    const tools = await appService.getTpaTools(packageName);
     
-    // Return the commands array
-    res.json(commands);
+    // Return the tools array
+    res.json(tools);
   } catch (error) {
-    logger.error('Error fetching TPA commands:', error);
+    logger.error('Error fetching TPA tools:', error);
     res.status(500).json({ 
       error: true,
       message: error instanceof Error ? error.message : 'Unknown error occurred' 
@@ -318,8 +318,8 @@ router.get('/apps/:packageName', validateAdminEmail, getAppDetail);
 router.post('/apps/:packageName/approve', validateAdminEmail, approveApp);
 router.post('/apps/:packageName/reject', validateAdminEmail, rejectApp);
 
-// Command webhook routes - Used by Mira AI
-router.post('/apps/:packageName/command', triggerCommand);
-router.get('/apps/:packageName/commands', getTpaCommands);
+// Tool webhook routes - Used by Mira AI
+router.post('/apps/:packageName/tool', triggerTool);
+router.get('/apps/:packageName/tools', getTpaTools);
 
 export default router;

--- a/augmentos_cloud/packages/cloud/src/routes/tools.routes.ts
+++ b/augmentos_cloud/packages/cloud/src/routes/tools.routes.ts
@@ -1,0 +1,148 @@
+// routes/tools.routes.ts
+import { Router, Request, Response } from 'express';
+import App from '../models/app.model';
+import { logger } from '@augmentos/utils';
+import { Exception } from '@sentry/node';
+import appService from '../services/core/app.service';
+import { User } from '../models/user.model';
+import { ToolCall } from '@augmentos/sdk';
+const router = Router();
+/**
+ * Trigger a tool webhook to a TPA
+ * Used by Mira AI to send tools to TPAs
+ */
+const triggerTool = async (req: Request, res: Response) => {
+  try {
+    console.log('🔨 Triggering tool for:', req.params.packageName);
+    console.log('🔨 Payload:', req.body);
+    const { packageName } = req.params;
+    const payload: ToolCall = req.body;
+    
+    // Validate the payload has the required fields
+    if (!payload.toolId) {
+      return res.status(400).json({ 
+        error: true, 
+        message: 'Missing required fields: toolId' 
+      });
+    }
+    if (!payload.userId) {
+      return res.status(400).json({ 
+        error: true, 
+        message: 'Missing required fields: userId' 
+      });
+    }
+    
+
+    // Log the tool request
+    logger.info(`Triggering tool webhook for app ${packageName}`, {
+      toolId: payload.toolId,
+      userId: payload.userId
+    });
+    
+    // Call the service method to trigger the webhook
+    const result = await appService.triggerTpaToolWebhook(packageName, payload);
+    
+    // Return the response from the TPA
+    return res.status(result.status).json(result.data);
+  } catch (error) {
+    logger.error('Error triggering tool webhook:', error);
+    return res.status(500).json({ 
+    error: true,
+    message: error instanceof Error ? error.message : 'Unknown error occurred' 
+    });
+  }
+  };
+  
+  /**
+   * Get all tools for a specific TPA
+   * Used by Mira AI to discover available tools
+   */
+  const getTpaTools = async (req: Request, res: Response) => {
+  try {
+    const { packageName } = req.params;
+    
+    // Call the service method to get the tools
+    const tools = await appService.getTpaTools(packageName);
+    
+    // Return the tools array
+    res.json(tools);
+  } catch (error) {
+    logger.error('Error fetching TPA tools:', error);
+    res.status(500).json({ 
+    error: true,
+    message: error instanceof Error ? error.message : 'Unknown error occurred' 
+    });
+  }
+  };
+  
+  /**
+   * Get all tools for a user's installed TPAs
+   * Used by Mira AI to discover all available tools for a user
+   */
+  const getUserTools = async (req: Request, res: Response) => {
+  try {
+    const { userId } = req.params;
+    
+    if (!userId) {
+    return res.status(400).json({ 
+      error: true, 
+      message: 'Missing required parameter: userId' 
+    });
+    }
+    
+    // Find the user by userId (email)
+    const user = await User.findOne({ email: userId });
+    
+    if (!user) {
+    return res.status(404).json({ 
+      error: true, 
+      message: 'User not found' 
+    });
+    }
+    
+    // Get list of installed app packageNames from user
+    const installedPackageNames = user.installedApps?.map(app => app.packageName) || [];
+    
+    if (installedPackageNames.length === 0) {
+    return res.json([]);
+    }
+    
+    // Collect all tools from all installed apps
+    const allUserTools = [];
+    
+    for (const packageName of installedPackageNames) {
+    try {
+      // Get tools for this app
+      const appTools = await appService.getTpaTools(packageName);
+      
+      // Add app identifier to each tool
+      const toolsWithAppInfo = appTools.map(tool => ({
+      ...tool,
+      appPackageName: packageName
+      }));
+      
+      allUserTools.push(...toolsWithAppInfo);
+    } catch (error) {
+      // Log error but continue with other apps
+      logger.error(`Error fetching tools for app ${packageName}:`, error);
+    }
+    }
+    
+    // Return the combined list of tools
+    res.json(allUserTools);
+  } catch (error) {
+    logger.error('Error fetching user tools:', error);
+    res.status(500).json({ 
+    error: true,
+    message: error instanceof Error ? error.message : 'Unknown error occurred' 
+    });
+  }
+};
+  
+
+// Tool webhook routes - Used by Mira AI
+router.post('/apps/:packageName/tool', triggerTool);
+router.get('/apps/:packageName/tools', getTpaTools);
+router.get('/users/:userId/tools', getUserTools);
+
+export default router;

--- a/augmentos_cloud/packages/sdk/src/tpa/server/index.ts
+++ b/augmentos_cloud/packages/sdk/src/tpa/server/index.ts
@@ -163,9 +163,8 @@ export class TpaServer {
    * @returns Optional string response that will be sent back to AugmentOS Cloud
    */
   protected async onToolCall(toolCall: ToolCall): Promise<string | undefined> {
-    console.log(`Tool call received: ${toolCall.toolName} (${toolCall.toolId})`);
+    console.log(`Tool call received: ${toolCall.toolId}`);
     console.log(`Parameters: ${JSON.stringify(toolCall.toolParameters)}`);
-    console.log(`Full transcript: ${toolCall.fullTranscript}`);
     return undefined;
   }
 
@@ -279,8 +278,9 @@ export class TpaServer {
   private setupToolCallEndpoint(): void {
     this.app.post('/tool', async (req, res) => {
       try {
+        console.log(`\n\n🔧 Received tool call: ${JSON.stringify(req.body)}\n\n`);
         const toolCall = req.body as ToolCall;
-        console.log(`\n\n🔧 Received tool call: ${toolCall.toolName} (${toolCall.toolId})\n\n`);
+        console.log(`\n\n🔧 Received tool call: ${toolCall.toolId}\n\n`);
         // Call the onToolCall handler and get the response
         const response = await this.onToolCall(toolCall);
         
@@ -297,6 +297,9 @@ export class TpaServer {
           message: error instanceof Error ? error.message : 'Unknown error occurred calling tool'
         });
       }
+    });
+    this.app.get('/tool', async (req, res) => {
+      res.json({ status: 'success', reply: 'Hello, world!' });
     });
   }
 

--- a/augmentos_cloud/packages/sdk/src/types/index.ts
+++ b/augmentos_cloud/packages/sdk/src/types/index.ts
@@ -82,7 +82,8 @@ export {
   AppStopped,
   SettingsUpdate,
   DataStream,
-  CloudToTpaMessage
+  CloudToTpaMessage,
+  ToolCall
 } from './messages/cloud-to-tpa';
 
 // From layout.ts

--- a/augmentos_cloud/packages/sdk/src/types/index.ts
+++ b/augmentos_cloud/packages/sdk/src/types/index.ts
@@ -129,7 +129,9 @@ export {
   BaseAppSetting,
   GroupSetting,
   TpaConfig,
-  validateTpaConfig
+  validateTpaConfig,
+  ToolSchema,
+  ToolParameterSchema
 } from './models';
 
 

--- a/augmentos_cloud/packages/sdk/src/types/messages/cloud-to-tpa.ts
+++ b/augmentos_cloud/packages/sdk/src/types/messages/cloud-to-tpa.ts
@@ -91,6 +91,20 @@ export interface AudioChunk extends BaseMessage {
   sampleRate?: number;  // Audio sample rate (e.g., 16000 Hz)
 }
 
+/**
+ * Tool call from cloud to TPA
+ * Represents a tool invocation with filled parameters
+ */
+export interface ToolCall {
+  toolId: string; // The ID of the tool that was called
+  toolName: string; // The name of the tool that was called
+  toolParameters: Record<string, string | number | boolean>; // The parameters of the tool that was called
+  fullTranscript: string; // The complete transcript that triggered this tool call
+  timestamp: Date; // Timestamp when the tool was called
+  userId: string; // ID of the user who triggered the tool call
+  parameterValues: Record<string, string | number | boolean>; // The actual parameter values filled in for this tool call
+}
+
 //===========================================================
 // Stream data
 //===========================================================
@@ -117,7 +131,8 @@ export type CloudToTpaMessage =
   | AudioChunk
   | LocationUpdate
   | CalendarEvent
-  | DataStream;
+  | DataStream
+  | ToolCall;
 
 //===========================================================
 // Type guards

--- a/augmentos_cloud/packages/sdk/src/types/messages/cloud-to-tpa.ts
+++ b/augmentos_cloud/packages/sdk/src/types/messages/cloud-to-tpa.ts
@@ -97,12 +97,9 @@ export interface AudioChunk extends BaseMessage {
  */
 export interface ToolCall {
   toolId: string; // The ID of the tool that was called
-  toolName: string; // The name of the tool that was called
   toolParameters: Record<string, string | number | boolean>; // The parameters of the tool that was called
-  fullTranscript: string; // The complete transcript that triggered this tool call
   timestamp: Date; // Timestamp when the tool was called
   userId: string; // ID of the user who triggered the tool call
-  parameterValues: Record<string, string | number | boolean>; // The actual parameter values filled in for this tool call
 }
 
 //===========================================================
@@ -131,8 +128,7 @@ export type CloudToTpaMessage =
   | AudioChunk
   | LocationUpdate
   | CalendarEvent
-  | DataStream
-  | ToolCall;
+  | DataStream;
 
 //===========================================================
 // Type guards

--- a/augmentos_cloud/packages/sdk/src/types/models.ts
+++ b/augmentos_cloud/packages/sdk/src/types/models.ts
@@ -3,6 +3,23 @@
 
 import { AppSettingType, AppState, Language, TpaType } from './enums';
 
+
+// Tool parameter type definition
+export interface ToolParameterSchema {
+  type: 'string' | 'number' | 'boolean';
+  description: string;
+  enum?: string[];
+  required?: boolean;
+}
+
+// Tool schema definition for TPAs
+export interface ToolSchema {
+  id: string;
+  description: string;
+  activationPhrases?: string[];
+  parameters?: Record<string, ToolParameterSchema>;
+}
+
 /**
  * Developer profile information
  */


### PR DESCRIPTION
Allow Third-Party Applications (TPAs) to define tools for use by Mira AI

**Proposed Solution:**

Introduce a system where TPAs can define specific tools, activation phrases, and parameters in their `tpa_config.json` file.

**Mira AI Activation (Webhook):**
The Mira AI assistant will be able to discover TPA tools via a new Cloud API. Mira presents these commands as tools to the AI. When Mira's AI decides to call a tool, Mira will send an HTTP POST request (webhook) to the TPA's `/command` endpoint with the command ID and parameters. The TPA will handle this request and can return a response.

**Key Features & Requirements:**

*   **Tool Definition:** Extend `tpa_config.json` schema to include a `tools` array, defining command `id`, `description`, `activationPhrases`, and `parameters` (with `key`, `description`, `type`, `required`).
*   **Cloud Service Logic:**
    *   Parse and store tool definitions from TPA configurations.
    *   Implement logic to trigger TPA `/tool` webhooks securely.
    *   Expose a Cloud API (`GET /api/apps/{packageName}/tools`) for Mira to discover TPA commands.
*   **SDK Enhancements (`@augmentos/sdk`):**
    *   Update `TpaServer` to automatically register a `POST /tool` webhook endpoint.
    *   Implement auth verification within the default `/tool` handler.


**Example command definition:**

```json
{
  "name": "My Awesome App",
  "description": "A demo app to show tool calling",
  "version": "1.0.0",
  "settings": [
    // ... existing settings ...
  ],
  "tools": [
    {
      "id": "add_note",
      "description": "Adds a new note with the spoken text.",
      "activationPhrases": [
        "add note",
        "take a note",
        "create note"
      ],
      "parameters": {
        "note_content": {
          "type": "string",
          "description": "The content of the note to be saved.",
          "required": true
        }
        
      }
    },
    {
      "id": "set_timer",
      "description": "Sets a timer for a specified duration.",
      "activationPhrases": [
        "set timer for",
        "start timer",
        "timer"
      ],
      "parameters": {
        "duration": {
          "type": "number",
          "description": "The duration of the timer in minutes.",
          "required": true
        },
        "timer_label": {
          "type": "string",
          "description": "An optional label for the timer.",
          "required": false
        }
      }
    },
    {
      "id": "get_weather",
      "description": "Retrieves current weather for the given location.",
      "activationPhrases": [
        "what's the weather in",
        "weather in",
        "get weather"
      ],
      "parameters": {
        "location": {
          "type": "string",
            "description": "City and country e.g. Bogotá, Colombia",
            "required": true
          },
        "units": {
          "type": "string",
          "enum": [
            "celsius",
            "fahrenheit"
          ],
          "description": "Units the temperature will be returned in.",
          "required": true
        }  
      }
    }
    // ... other commands ...
  ]
}
```